### PR TITLE
Parse view transactions

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListTransactionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListTransactionCommand.java
@@ -1,0 +1,45 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.IsSelectedPredicate;
+import seedu.address.model.person.Person;
+
+/**
+ * Lists all transactions for the selected person.
+ */
+public class ListTransactionCommand extends Command {
+    public static final String COMMAND_WORD = "listt";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": lists transactions for selected person. "
+            + "Parameter: index of person";
+    public static final String MESSAGE_SUCCESS = "Listed transactions for %1$s";
+
+    private final Index index;
+
+    /**
+     * @param index the index of the person to view transactions of.
+     */
+    public ListTransactionCommand(Index index) {
+        requireNonNull(index);
+        this.index = index;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person selected = lastShownList.get(index.getZeroBased());
+        model.updateFilteredPersonList(new IsSelectedPredicate(model, index));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(selected)));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ListTransactionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListTransactionCommand.java
@@ -42,4 +42,16 @@ public class ListTransactionCommand extends Command {
         model.updateFilteredPersonList(new IsSelectedPredicate(model, index));
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(selected)));
     }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof ListTransactionCommand)) {
+            return false;
+        }
+        ListTransactionCommand otherCommand = (ListTransactionCommand) other;
+        return this.index.equals(otherCommand.index);
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ListTransactionCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -70,6 +71,9 @@ public class AddressBookParser {
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();
+
+        case ListTransactionCommand.COMMAND_WORD:
+            return new ListTransactionCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/logic/parser/ListTransactionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListTransactionCommandParser.java
@@ -1,0 +1,28 @@
+package seedu.address.logic.parser;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.ListTransactionCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and returns a new ListTransactionCommand object.
+ */
+public class ListTransactionCommandParser implements Parser<ListTransactionCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the ListTransactionCommand
+     * and returns a ListTransactionCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    @Override
+    public ListTransactionCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new ListTransactionCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, ListTransactionCommand.MESSAGE_USAGE)
+            );
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/person/IsSelectedPredicate.java
+++ b/src/main/java/seedu/address/model/person/IsSelectedPredicate.java
@@ -1,0 +1,29 @@
+package seedu.address.model.person;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.function.Predicate;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.Model;
+
+/**
+ * Tests if a {@code Person} has been selected by the user.
+ */
+public class IsSelectedPredicate implements Predicate<Person> {
+    private final Person person;
+
+    /**
+     * @param model current state of address book.
+     * @param index the index of the person selected.
+     */
+    public IsSelectedPredicate(Model model, Index index) {
+        requireAllNonNull(model, index);
+        this.person = model.getFilteredPersonList().get(index.getZeroBased());
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return this.person.isSamePerson(person);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ListTransactionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListTransactionCommandTest.java
@@ -1,8 +1,11 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
@@ -17,7 +20,7 @@ public class ListTransactionCommandTest {
     private Model expectedModel;
 
     @Test
-    public void execute_listTransactions_success() {
+    public void execute_listAllTransactions_success() {
         model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
@@ -25,5 +28,27 @@ public class ListTransactionCommandTest {
                 String.format(ListTransactionCommand.MESSAGE_SUCCESS,
                         Messages.format(expectedModel.getFilteredPersonList().get(0))),
                 expectedModel);
+    }
+
+    @Test
+    public void equals() {
+        ListTransactionCommand command1 = new ListTransactionCommand(INDEX_FIRST_PERSON);
+        ListTransactionCommand command2 = new ListTransactionCommand(INDEX_FIRST_PERSON);
+        ListTransactionCommand command3 = new ListTransactionCommand(INDEX_SECOND_PERSON);
+
+        // same object -> return true
+        assertTrue(command1.equals(command1));
+
+        // different object but same index -> return true
+        assertTrue(command1.equals(command2));
+
+        // different index -> return true
+        assertFalse(command1.equals(command3));
+
+        // compare object with null -> return false
+        assertFalse(command1.equals(null));
+
+        // compare with other types of command -> return false
+        assertFalse(command1.equals(new ListCommand()));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListTransactionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListTransactionCommandTest.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+public class ListTransactionCommandTest {
+    private Model model;
+    private Model expectedModel;
+
+    @Test
+    public void execute_listTransactions_success() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
+        assertCommandSuccess(new ListTransactionCommand(INDEX_FIRST_PERSON), model,
+                String.format(ListTransactionCommand.MESSAGE_SUCCESS,
+                        Messages.format(expectedModel.getFilteredPersonList().get(0))),
+                expectedModel);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -22,6 +22,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ListTransactionCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
@@ -86,6 +87,13 @@ public class AddressBookParserTest {
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_listTransaction() throws Exception {
+        ListTransactionCommand command = (ListTransactionCommand) parser.parseCommand(
+                ListTransactionCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
+        assertEquals(new ListTransactionCommand(INDEX_FIRST_PERSON), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ListTransactionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ListTransactionCommandParserTest.java
@@ -1,0 +1,32 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.ListTransactionCommand;
+
+public class ListTransactionCommandParserTest {
+    private ListTransactionCommandParser parser = new ListTransactionCommandParser();
+
+    @Test
+    public void parse_validInput_success() {
+        assertParseSuccess(parser, "1", new ListTransactionCommand(INDEX_FIRST_PERSON));
+    }
+
+    @Test
+    public void parse_invalidInput_throwsParseException() {
+        // user input not a number
+        assertParseFailure(parser, "a",
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, ListTransactionCommand.MESSAGE_USAGE));
+
+        // empty user input
+        assertParseFailure(parser, "",
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, ListTransactionCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " ",
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, ListTransactionCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/model/person/IsSelectedPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/IsSelectedPredicateTest.java
@@ -1,0 +1,28 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+public class IsSelectedPredicateTest {
+    @Test
+    public void test_samePerson_returnsTrue() {
+        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        IsSelectedPredicate predicate = new IsSelectedPredicate(model, INDEX_FIRST_PERSON);
+        assertTrue(predicate.test(model.getFilteredPersonList().get(0)));
+    }
+
+    @Test
+    public void test_differentPerson_returnsFalse() {
+        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        IsSelectedPredicate predicate = new IsSelectedPredicate(model, INDEX_FIRST_PERSON);
+        assertFalse(predicate.test(model.getFilteredPersonList().get(2)));
+    }
+}


### PR DESCRIPTION
Fixes #40 

This code change sets up infrastructure for `listt` command, without showing the actual transactions yet. It currently displays the person selected.