### PR TITLE
Add person list filter back

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindTransactionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindTransactionCommand.java
@@ -9,6 +9,7 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.IsSelectedPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Transaction;
 import seedu.address.model.person.TransactionContainsKeywordsPredicate;
@@ -24,7 +25,7 @@ public class FindTransactionCommand extends Command {
             + ": Finds all transactions of the person of specific index whose descriptions contain any of "
             + "the keywords. (case-insensitive)\n"
             + "ONLY use this command when you are viewing the person list.\n"
-            + "Parameters: PERSON_INDEX KEYWORD [MORE_KEYWORDS]...\n"
+            + "Parameters: PERSON_INDEX (positive integer) KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " 1 food transport";
 
     private final Index personIndex;
@@ -48,6 +49,7 @@ public class FindTransactionCommand extends Command {
         }
         Person targetPerson = lastShownList.get(personIndex.getZeroBased());
         List<Transaction> targetTransactions = targetPerson.getTransactions();
+        model.updateFilteredPersonList(new IsSelectedPredicate(model, personIndex));
         model.setViewTransactions(true);
         model.updateTransactionList(targetTransactions);
         model.updateTransactionListPredicate(predicate);

--- a/src/main/java/seedu/address/logic/commands/ListTransactionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListTransactionCommand.java
@@ -8,6 +8,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.IsSelectedPredicate;
 import seedu.address.model.person.Person;
 
 /**
@@ -38,6 +39,7 @@ public class ListTransactionCommand extends Command {
         }
 
         Person selected = lastShownList.get(index.getZeroBased());
+        model.updateFilteredPersonList(new IsSelectedPredicate(model, index));
         model.setViewTransactions(true);
         model.updateTransactionList(selected.getTransactions());
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(selected)));

--- a/src/test/java/seedu/address/logic/commands/FindTransactionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindTransactionCommandTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_TRANSACTIONS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
@@ -64,6 +65,7 @@ public class FindTransactionCommandTest {
         String expectedMessage = String.format(MESSAGE_TRANSACTIONS_LISTED_OVERVIEW, 0, Messages.format(CARL));
         TransactionContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindTransactionCommand command = new FindTransactionCommand(Index.fromOneBased(3), predicate);
+        showPersonAtIndex(expectedModel, Index.fromOneBased(3));
         expectedModel.updateTransactionList(CARL.getTransactions());
         expectedModel.updateTransactionListPredicate(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -76,6 +78,7 @@ public class FindTransactionCommandTest {
         String expectedMessage = String.format(MESSAGE_TRANSACTIONS_LISTED_OVERVIEW, 2, Messages.format(CARL));
         TransactionContainsKeywordsPredicate predicate = preparePredicate("raw materials invest");
         FindTransactionCommand command = new FindTransactionCommand(Index.fromOneBased(3), predicate);
+        showPersonAtIndex(expectedModel, Index.fromOneBased(3));
         expectedModel.updateTransactionList(CARL.getTransactions());
         expectedModel.updateTransactionListPredicate(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/address/logic/commands/ListTransactionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListTransactionCommandTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -22,6 +23,7 @@ public class ListTransactionCommandTest {
     public void execute_listAllTransactions_success() {
         model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
         assertCommandSuccess(new ListTransactionCommand(INDEX_FIRST_PERSON), model,
                 String.format(ListTransactionCommand.MESSAGE_SUCCESS,
                         Messages.format(expectedModel.getFilteredPersonList().get(0))),


### PR DESCRIPTION
When a person's transaction list is shown, we need the person list to be filtered so that it only contains the person whose transaction is currently shown. It is how it remembers whose transactions are shown now so that we can perform `deletet` on the correct person. 

I thought this was not needed and removed it yesterday, so now I added it back.