### PR TITLE
Fix transactions commands

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -94,6 +94,6 @@ public class LogicManager implements Logic {
 
     @Override
     public boolean isViewTransactions() {
-        return model.getViewTransactions();
+        return model.getIsViewTransactions();
     }
 }

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -28,6 +28,9 @@ public class Messages {
     public static final String MESSAGE_INVALID_MONTH_FORMAT = "Invalid month format!\nMonth format: yyyy-MM";
     public static final String MESSAGE_INVALID_DATE_RANGE = "Invalid date range!\n"
             + "Start date must be before or equal to end date";
+    public static final String MESSAGE_MUST_BE_TRANSACTION_LIST = "%1$s must only be used in transaction list view!";
+    public static final String MESSAGE_MUST_BE_PERSON_LIST = "%1$s must only be used in person list view!";
+
     /**
      * Returns an error message indicating the duplicate prefixes.
      */

--- a/src/main/java/seedu/address/logic/commands/AddTransactionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTransactionCommand.java
@@ -58,6 +58,11 @@ public class AddTransactionCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
 
         requireNonNull(model);
+
+        if (model.getIsViewTransactions()) {
+            throw new CommandException(String.format(Messages.MESSAGE_MUST_BE_PERSON_LIST, COMMAND_WORD));
+        }
+
         List<Person> lastShownList = model.getFilteredPersonList();
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/DeleteTransactionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTransactionCommand.java
@@ -37,6 +37,10 @@ public class DeleteTransactionCommand extends Command {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
 
+        if (!model.getIsViewTransactions()) {
+            throw new CommandException(String.format(Messages.MESSAGE_MUST_BE_TRANSACTION_LIST, COMMAND_WORD));
+        }
+
         if (CURRENT_PERSON.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }

--- a/src/main/java/seedu/address/logic/commands/FindTransactionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindTransactionCommand.java
@@ -55,7 +55,7 @@ public class FindTransactionCommand extends Command {
         Person targetPerson = lastShownList.get(personIndex.getZeroBased());
         List<Transaction> targetTransactions = targetPerson.getTransactions();
         model.updateFilteredPersonList(new IsSelectedPredicate(model, personIndex));
-        model.setViewTransactions(true);
+        //model.setViewTransactions(true);
         model.updateTransactionList(targetTransactions);
         model.updateTransactionListPredicate(predicate);
         return new CommandResult(

--- a/src/main/java/seedu/address/logic/commands/FindTransactionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindTransactionCommand.java
@@ -55,7 +55,6 @@ public class FindTransactionCommand extends Command {
         Person targetPerson = lastShownList.get(personIndex.getZeroBased());
         List<Transaction> targetTransactions = targetPerson.getTransactions();
         model.updateFilteredPersonList(new IsSelectedPredicate(model, personIndex));
-        //model.setViewTransactions(true);
         model.updateTransactionList(targetTransactions);
         model.updateTransactionListPredicate(predicate);
         return new CommandResult(

--- a/src/main/java/seedu/address/logic/commands/FindTransactionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindTransactionCommand.java
@@ -43,6 +43,11 @@ public class FindTransactionCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
+        if (model.getIsViewTransactions()) {
+            throw new CommandException(String.format(Messages.MESSAGE_MUST_BE_PERSON_LIST, COMMAND_WORD));
+        }
+
         List<Person> lastShownList = model.getFilteredPersonList();
         if (personIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/ListTransactionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListTransactionCommand.java
@@ -33,6 +33,11 @@ public class ListTransactionCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
+        if (model.getIsViewTransactions()) {
+            throw new CommandException(String.format(Messages.MESSAGE_MUST_BE_PERSON_LIST, COMMAND_WORD));
+        }
+
         List<Person> lastShownList = model.getFilteredPersonList();
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/ListTransactionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListTransactionCommand.java
@@ -45,7 +45,7 @@ public class ListTransactionCommand extends Command {
 
         Person selected = lastShownList.get(index.getZeroBased());
         model.updateFilteredPersonList(new IsSelectedPredicate(model, index));
-        model.setViewTransactions(true);
+        //model.setViewTransactions(true);
         model.updateTransactionList(selected.getTransactions());
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(selected)));
     }

--- a/src/main/java/seedu/address/logic/commands/ListTransactionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListTransactionCommand.java
@@ -45,7 +45,6 @@ public class ListTransactionCommand extends Command {
 
         Person selected = lastShownList.get(index.getZeroBased());
         model.updateFilteredPersonList(new IsSelectedPredicate(model, index));
-        //model.setViewTransactions(true);
         model.updateTransactionList(selected.getTransactions());
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(selected)));
     }

--- a/src/main/java/seedu/address/logic/commands/SummaryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SummaryCommand.java
@@ -10,6 +10,8 @@ import java.time.YearMonth;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Transaction;
 
@@ -43,8 +45,13 @@ public class SummaryCommand extends Command {
         this.endMonth = end;
     }
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
+        if (!model.getIsViewTransactions()) {
+            throw new CommandException(String.format(Messages.MESSAGE_MUST_BE_TRANSACTION_LIST, COMMAND_WORD));
+        }
+
         LocalDate startDate = startMonth.atDay(1);
         LocalDate endDate = endMonth.atEndOfMonth();
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -112,7 +112,7 @@ public interface Model {
     /**
      * Determines if transaction view or person view is used.
      */
-    boolean getViewTransactions();
+    boolean getIsViewTransactions();
 
     /**
      * Updates the transaction list to contain the specified transactions.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -107,7 +107,7 @@ public interface Model {
     /**
      * Specifies if transaction view or person view is used.
      */
-    void setViewTransactions(boolean newValue);
+    void setIsViewTransactions(boolean newValue);
 
     /**
      * Determines if transaction view or person view is used.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -132,8 +132,8 @@ public class ModelManager implements Model {
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
-        setViewTransactions(false);
         updateTransactionList(List.of());
+        setViewTransactions(false);
     }
 
     //=========== Transaction =============================================================
@@ -165,6 +165,7 @@ public class ModelManager implements Model {
     @Override
     public void updateTransactionList(List<Transaction> transactions) {
         this.filteredTransactions = new FilteredList<>(FXCollections.observableList(transactions));
+        setViewTransactions(true);
     }
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -133,7 +133,7 @@ public class ModelManager implements Model {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
         updateTransactionList(List.of());
-        setViewTransactions(false);
+        setIsViewTransactions(false);
     }
 
     //=========== Transaction =============================================================
@@ -154,7 +154,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void setViewTransactions(boolean viewTransactions) {
+    public void setIsViewTransactions(boolean viewTransactions) {
         this.isViewTransactions = viewTransactions;
     }
 
@@ -165,7 +165,7 @@ public class ModelManager implements Model {
     @Override
     public void updateTransactionList(List<Transaction> transactions) {
         this.filteredTransactions = new FilteredList<>(FXCollections.observableList(transactions));
-        setViewTransactions(true);
+        setIsViewTransactions(true);
     }
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -133,6 +133,7 @@ public class ModelManager implements Model {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
         setViewTransactions(false);
+        updateTransactionList(List.of());
     }
 
     //=========== Transaction =============================================================
@@ -158,7 +159,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public boolean getViewTransactions() {
+    public boolean getIsViewTransactions() {
         return this.isViewTransactions;
     }
     @Override

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -179,7 +179,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public boolean getViewTransactions() {
+        public boolean getIsViewTransactions() {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -174,7 +174,7 @@ public class AddCommandTest {
             throw new AssertionError("This method should not be called.");
         }
         @Override
-        public void setViewTransactions(boolean isViewTransaction) {
+        public void setIsViewTransactions(boolean isViewTransaction) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/AddTransactionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddTransactionCommandTest.java
@@ -111,6 +111,16 @@ public class AddTransactionCommandTest {
         assertCommandFailure(addTransactionCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
+    @Test
+    public void execute_transactionListView_throwsCommandException() {
+        Transaction transactionToAdd = new Transaction("buy raw materials", -100,
+                "Company ABC", LocalDate.parse("2024-10-15", DateTimeUtil.DEFAULT_DATE_PARSER));
+        AddTransactionCommand addTransactionCommand = new AddTransactionCommand(INDEX_FIRST_PERSON, transactionToAdd);
+        model.setViewTransactions(true);
+        String expectedMessage = String.format(Messages.MESSAGE_MUST_BE_PERSON_LIST, "addt");
+        assertCommandFailure(addTransactionCommand, model, expectedMessage);
+    }
+
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/address/logic/commands/AddTransactionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddTransactionCommandTest.java
@@ -116,7 +116,7 @@ public class AddTransactionCommandTest {
         Transaction transactionToAdd = new Transaction("buy raw materials", -100,
                 "Company ABC", LocalDate.parse("2024-10-15", DateTimeUtil.DEFAULT_DATE_PARSER));
         AddTransactionCommand addTransactionCommand = new AddTransactionCommand(INDEX_FIRST_PERSON, transactionToAdd);
-        model.setViewTransactions(true);
+        model.setIsViewTransactions(true);
         String expectedMessage = String.format(Messages.MESSAGE_MUST_BE_PERSON_LIST, "addt");
         assertCommandFailure(addTransactionCommand, model, expectedMessage);
     }

--- a/src/test/java/seedu/address/logic/commands/DeleteTransactionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTransactionCommandTest.java
@@ -49,7 +49,7 @@ public class DeleteTransactionCommandTest {
     }
 
     @Test
-    public void execute_emptyFilteredTransactionList() {
+    public void execute_emptyFilteredTransactionList_throwsCommandException() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
         List<Transaction> transactions = new ArrayList<>();
         model.updateTransactionList(transactions);
@@ -61,17 +61,26 @@ public class DeleteTransactionCommandTest {
     }
 
     @Test
-    public void execute_unfilteredListFailure() {
+    public void execute_unfilteredListFailure_throwsCommandException() {
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
 
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
         showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
+        model.setViewTransactions(true);
 
         String expectedMessage = Messages.MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX;
 
         DeleteTransactionCommand deleteTransactionCommand = new DeleteTransactionCommand(INDEX_FIRST_TRANSACTION);
         assertCommandFailure(deleteTransactionCommand, model, expectedMessage);
     }
+
+    @Test
+    public void execute_personListView_throwsCommandException() {
+        DeleteTransactionCommand deleteTransactionCommand = new DeleteTransactionCommand(INDEX_FIRST_TRANSACTION);
+        String expectedMessage = String.format(Messages.MESSAGE_MUST_BE_TRANSACTION_LIST, "deletet");
+        assertCommandFailure(deleteTransactionCommand, model, expectedMessage);
+    }
+
     @Test
     public void equals() {
         DeleteTransactionCommand deleteFirstCommand = new DeleteTransactionCommand(INDEX_FIRST_TRANSACTION);

--- a/src/test/java/seedu/address/logic/commands/DeleteTransactionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTransactionCommandTest.java
@@ -66,7 +66,7 @@ public class DeleteTransactionCommandTest {
 
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
         showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
-        model.setViewTransactions(true);
+        model.setIsViewTransactions(true);
 
         String expectedMessage = Messages.MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX;
 

--- a/src/test/java/seedu/address/logic/commands/FindTransactionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindTransactionCommandTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_TRANSACTIONS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalPersons.CARL;
@@ -83,6 +84,15 @@ public class FindTransactionCommandTest {
         expectedModel.updateTransactionListPredicate(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(CARL.getTransactions(), model.getFilteredTransactionList());
+    }
+
+    @Test
+    public void execute_transactionListView_throwsCommandException() {
+        TransactionContainsKeywordsPredicate predicate = preparePredicate(" ");
+        FindTransactionCommand command = new FindTransactionCommand(Index.fromOneBased(3), predicate);
+        model.setViewTransactions(true);
+        String expectedMessage = String.format(Messages.MESSAGE_MUST_BE_PERSON_LIST, "findt");
+        assertCommandFailure(command, model, expectedMessage);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/FindTransactionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindTransactionCommandTest.java
@@ -90,7 +90,7 @@ public class FindTransactionCommandTest {
     public void execute_transactionListView_throwsCommandException() {
         TransactionContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindTransactionCommand command = new FindTransactionCommand(Index.fromOneBased(3), predicate);
-        model.setViewTransactions(true);
+        model.setIsViewTransactions(true);
         String expectedMessage = String.format(Messages.MESSAGE_MUST_BE_PERSON_LIST, "findt");
         assertCommandFailure(command, model, expectedMessage);
     }

--- a/src/test/java/seedu/address/logic/commands/ListTransactionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListTransactionCommandTest.java
@@ -32,7 +32,7 @@ public class ListTransactionCommandTest {
     @Test
     public void execute_transactionListView_throwsCommandException() {
         ListTransactionCommand command = new ListTransactionCommand(INDEX_FIRST_PERSON);
-        model.setViewTransactions(true);
+        model.setIsViewTransactions(true);
         String expectedMessage = String.format(Messages.MESSAGE_MUST_BE_PERSON_LIST, "listt");
         assertCommandFailure(command, model, expectedMessage);
     }

--- a/src/test/java/seedu/address/logic/commands/ListTransactionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListTransactionCommandTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -16,18 +17,24 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 
 public class ListTransactionCommandTest {
-    private Model model;
-    private Model expectedModel;
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
 
     @Test
     public void execute_listAllTransactions_success() {
-        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
         assertCommandSuccess(new ListTransactionCommand(INDEX_FIRST_PERSON), model,
                 String.format(ListTransactionCommand.MESSAGE_SUCCESS,
                         Messages.format(expectedModel.getFilteredPersonList().get(0))),
                 expectedModel);
+    }
+
+    @Test
+    public void execute_transactionListView_throwsCommandException() {
+        ListTransactionCommand command = new ListTransactionCommand(INDEX_FIRST_PERSON);
+        model.setViewTransactions(true);
+        String expectedMessage = String.format(Messages.MESSAGE_MUST_BE_PERSON_LIST, "listt");
+        assertCommandFailure(command, model, expectedMessage);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/SummaryCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SummaryCommandTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.util.DateTimeUtil.DEFAULT_DATE_FORMATTER;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalPersons.CARL;
@@ -13,6 +14,7 @@ import java.time.YearMonth;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -84,5 +86,13 @@ public class SummaryCommandTest {
                         YearMonth.parse("2024-08").atDay(1).format(DEFAULT_DATE_FORMATTER),
                         YearMonth.parse("2024-11").atEndOfMonth().format(DEFAULT_DATE_FORMATTER), -1100.0),
                 expectedModel);
+    }
+
+    @Test
+    public void execute_personListView_throwsCommandException() {
+        SummaryCommand summaryCommand = new SummaryCommand(YearMonth.parse("2024-08"),
+                YearMonth.parse("2024-08"));
+        String expectedMessage = String.format(Messages.MESSAGE_MUST_BE_TRANSACTION_LIST, "summary");
+        assertCommandFailure(summaryCommand, model, expectedMessage);
     }
 }


### PR DESCRIPTION
This PR fixes:

- Clears transactions list when user requests to `list`
- Updates code to throw exception when the user access the commands in the wrong view (transaction vs person view).

Fixes #99 , fixes #116 , fixes #120