### PR TITLE
Sort person list by name

### DIFF
--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -3,6 +3,7 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
@@ -46,6 +47,7 @@ public class UniquePersonList implements Iterable<Person> {
             throw new DuplicatePersonException();
         }
         internalList.add(toAdd);
+        internalList.sort(Comparator.comparing(p -> p.getName().fullName));
     }
 
     /**


### PR DESCRIPTION
Fixes #106 
Sort the whole person list alphabetically by sorting it every time a new person is added. This ensures that the person view (either generated by `list` or `find`) is always sorted alphabetically.