### PR TITLE
Update `addt` message

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -25,8 +25,9 @@ public class Messages {
     public static final String MESSAGE_TRANSACTIONS_LISTED_OVERVIEW = "Listed %1$d transaction(s) of %2$s";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
-    public static final String MESSAGE_INVALID_AMOUNT = "Invalid amount!\n"
-            + "Amount should be a number up to 2 decimals places and should not contain any commas.";
+    public static final String MESSAGE_INVALID_AMOUNT = "Incorrect amount format or invalid amount!\n"
+            + "Amount should be a number of up to 2 decimal places containing only digits (0-9) and 1 decimal point. "
+            + "There should be at least 1 digit before the decimal point.";
     public static final String MESSAGE_INVALID_DATE_FORMAT = "Incorrect date format or invalid date!\n"
             + "Date format: YYYY-MM-DD";
     public static final String MESSAGE_INVALID_MONTH_FORMAT = "Incorrect month format or invalid month!\n"

--- a/src/main/java/seedu/address/logic/commands/AddTransactionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTransactionCommand.java
@@ -34,8 +34,8 @@ public class AddTransactionCommand extends Command {
             + PREFIX_OTHER_PARTY + "OTHER PARTY "
             + PREFIX_DATE + "DATE\n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_DESCRIPTION + "buy raw materials "
-            + PREFIX_AMOUNT + "-100.50 "
+            + PREFIX_DESCRIPTION + "buy new equipment "
+            + PREFIX_AMOUNT + "-1000.55 "
             + PREFIX_OTHER_PARTY + "Company XYZ "
             + PREFIX_DATE + "2024-10-10";
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -167,7 +167,7 @@ public class ParserUtil {
         try {
             amount = Double.parseDouble(trimmedAmount);
         } catch (NumberFormatException e) {
-            logger.fine("ParseException caused by invalid amount.");
+            logger.fine("ParseException caused by invalid amount or incorrect amount format.");
             throw new ParseException(Messages.MESSAGE_INVALID_AMOUNT);
         }
         return amount;

--- a/src/main/java/seedu/address/model/person/Transaction.java
+++ b/src/main/java/seedu/address/model/person/Transaction.java
@@ -14,9 +14,8 @@ public class Transaction {
     public static final String MESSAGE_CONSTRAINTS =
             """
             Amount should have at most 2 decimal places.
-            It should contain only digits(0-9) and one optional decimal point(.)
-            with no other symbols. There should be at least 1 digit before
-            the decimal point.
+            It should contain only digits (0-9) and one optional decimal point (.) with no other symbols.
+            There should be at least 1 digit before the decimal point.
             """;
     public static final String VALIDATION_REGEX = "^-?\\d+(,\\d{3})*(\\.\\d{1,2})?$";
     private final String description;


### PR DESCRIPTION
Fixes #160 

![image](https://github.com/user-attachments/assets/316330db-3c3e-4eca-b324-1f91140e5fbe)

In the current implementation the regex in Transaction class does not catch that `1,000` with a comma symbol is an invalid amount, but this is handled by the exception `parseAmount()` which throws a ParseException when parsing.