### PR TITLE
Change `findt` to be used in transaction view

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindTransactionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindTransactionCommand.java
@@ -4,14 +4,11 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 
-import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.person.IsSelectedPredicate;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.Transaction;
 import seedu.address.model.person.TransactionContainsKeywordsPredicate;
 
 /**
@@ -22,21 +19,18 @@ public class FindTransactionCommand extends Command {
     public static final String COMMAND_WORD = "findt";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Finds all transactions of the person of specific index whose descriptions contain any of "
+            + ": Finds all transactions in the current view whose descriptions contain any of "
             + "the keywords. (case-insensitive)\n"
-            + "ONLY use this command when you are viewing the person list.\n"
-            + "Parameters: PERSON_INDEX (positive integer) KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " 1 food transport";
-
-    private final Index personIndex;
+            + "ONLY use this command when you are viewing the transaction list.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " food transport";
     private final TransactionContainsKeywordsPredicate predicate;
 
     /**
-     * Creates a FindTransactionCommand to find the transactions of a given {@code Index} of a person
+     * Creates a FindTransactionCommand to find the transactions
      * that meet the specified {@code TransactionContainsKeywordsPredicate}
      */
-    public FindTransactionCommand(Index presonIndex, TransactionContainsKeywordsPredicate predicate) {
-        this.personIndex = presonIndex;
+    public FindTransactionCommand(TransactionContainsKeywordsPredicate predicate) {
         this.predicate = predicate;
     }
 
@@ -44,18 +38,12 @@ public class FindTransactionCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (model.getIsViewTransactions()) {
-            throw new CommandException(String.format(Messages.MESSAGE_MUST_BE_PERSON_LIST, COMMAND_WORD));
+        if (!model.getIsViewTransactions()) {
+            throw new CommandException(String.format(Messages.MESSAGE_MUST_BE_TRANSACTION_LIST, COMMAND_WORD));
         }
 
         List<Person> lastShownList = model.getFilteredPersonList();
-        if (personIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
-        }
-        Person targetPerson = lastShownList.get(personIndex.getZeroBased());
-        List<Transaction> targetTransactions = targetPerson.getTransactions();
-        model.updateFilteredPersonList(new IsSelectedPredicate(model, personIndex));
-        model.updateTransactionList(targetTransactions);
+        Person targetPerson = lastShownList.get(0);
         model.updateTransactionListPredicate(predicate);
         return new CommandResult(
                 String.format(Messages.MESSAGE_TRANSACTIONS_LISTED_OVERVIEW,
@@ -74,8 +62,7 @@ public class FindTransactionCommand extends Command {
         }
 
         FindTransactionCommand otherFindTransactionCommand = (FindTransactionCommand) other;
-        return personIndex.equals(otherFindTransactionCommand.personIndex)
-                && predicate.equals(otherFindTransactionCommand.predicate);
+        return predicate.equals(otherFindTransactionCommand.predicate);
     }
     @Override
     public String toString() {

--- a/src/main/java/seedu/address/logic/parser/FindTransactionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindTransactionCommandParser.java
@@ -4,7 +4,6 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Arrays;
 
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.FindTransactionCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.TransactionContainsKeywordsPredicate;
@@ -20,35 +19,12 @@ public class FindTransactionCommandParser implements Parser<FindTransactionComma
      * @throws ParseException if the user input does not conform the expected format.
      */
     public FindTransactionCommand parse(String args) throws ParseException {
-        // first item is index, the rest are keywords
-        String[] transactionKeywords = getStrings(args);
-        Index index;
-        try {
-            index = ParserUtil.parseIndex(transactionKeywords[0]);
-            // remove the first item (index)
-            transactionKeywords = Arrays.copyOfRange(transactionKeywords, 1, transactionKeywords.length);
-        } catch (ParseException e) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindTransactionCommand.MESSAGE_USAGE));
-        }
-        return new FindTransactionCommand(index,
-                new TransactionContainsKeywordsPredicate(Arrays.asList(transactionKeywords)));
-    }
-
-    private String[] getStrings(String args) throws ParseException {
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindTransactionCommand.MESSAGE_USAGE));
         }
-
-        // first item is index, the rest are keywords
         String[] transactionKeywords = trimmedArgs.split("\\s+");
-        // check if there is at least 2 items (index and at least 1 keyword)
-        if (transactionKeywords.length < 2) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindTransactionCommand.MESSAGE_USAGE));
-        }
-        return transactionKeywords;
+        return new FindTransactionCommand(new TransactionContainsKeywordsPredicate(Arrays.asList(transactionKeywords)));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/FindTransactionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindTransactionCommandTest.java
@@ -33,19 +33,14 @@ public class FindTransactionCommandTest {
         TransactionContainsKeywordsPredicate secondPredicate =
                 new TransactionContainsKeywordsPredicate(Collections.singletonList("second"));
 
-        FindTransactionCommand findFirstCommand =
-                new FindTransactionCommand(Index.fromOneBased(1), firstPredicate);
-        FindTransactionCommand findSecondCommand =
-                new FindTransactionCommand(Index.fromOneBased(1), secondPredicate);
-        FindTransactionCommand findThirdCommand =
-                new FindTransactionCommand(Index.fromOneBased(2), secondPredicate);
+        FindTransactionCommand findFirstCommand = new FindTransactionCommand(firstPredicate);
+        FindTransactionCommand findSecondCommand = new FindTransactionCommand(secondPredicate);
 
         // same object -> returns true
         assertTrue(findFirstCommand.equals(findFirstCommand));
 
         // same values -> returns true
-        FindTransactionCommand findFirstCommandCopy =
-                new FindTransactionCommand(Index.fromOneBased(1), firstPredicate);
+        FindTransactionCommand findFirstCommandCopy = new FindTransactionCommand(firstPredicate);
         assertTrue(findFirstCommand.equals(findFirstCommandCopy));
 
         // different types -> returns false
@@ -56,8 +51,6 @@ public class FindTransactionCommandTest {
 
         // different predicate -> returns false
         assertFalse(findFirstCommand.equals(findSecondCommand));
-        // different index -> returns false
-        assertFalse(findSecondCommand.equals(findThirdCommand));
     }
 
     @Test
@@ -65,9 +58,17 @@ public class FindTransactionCommandTest {
         // Find transactions of Carl
         String expectedMessage = String.format(MESSAGE_TRANSACTIONS_LISTED_OVERVIEW, 0, Messages.format(CARL));
         TransactionContainsKeywordsPredicate predicate = preparePredicate(" ");
-        FindTransactionCommand command = new FindTransactionCommand(Index.fromOneBased(3), predicate);
+        FindTransactionCommand command = new FindTransactionCommand(predicate);
+        // set person list to contain only the target person
+        showPersonAtIndex(model, Index.fromOneBased(3));
         showPersonAtIndex(expectedModel, Index.fromOneBased(3));
+        // set isViewTransactions to true
+        model.setIsViewTransactions(true);
+        expectedModel.setIsViewTransactions(true);
+        // update transaction list to contain only the target person's transactions
+        model.updateTransactionList(CARL.getTransactions());
         expectedModel.updateTransactionList(CARL.getTransactions());
+        // find transactions in expectedModel
         expectedModel.updateTransactionListPredicate(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredTransactionList());
@@ -78,9 +79,17 @@ public class FindTransactionCommandTest {
         // Find transactions of Carl
         String expectedMessage = String.format(MESSAGE_TRANSACTIONS_LISTED_OVERVIEW, 2, Messages.format(CARL));
         TransactionContainsKeywordsPredicate predicate = preparePredicate("raw materials invest");
-        FindTransactionCommand command = new FindTransactionCommand(Index.fromOneBased(3), predicate);
+        FindTransactionCommand command = new FindTransactionCommand(predicate);
+        // set person list to contain only the target person
+        showPersonAtIndex(model, Index.fromOneBased(3));
         showPersonAtIndex(expectedModel, Index.fromOneBased(3));
+        // set isViewTransactions to true
+        model.setIsViewTransactions(true);
+        expectedModel.setIsViewTransactions(true);
+        // update transaction list to contain only the target person's transactions
+        model.updateTransactionList(CARL.getTransactions());
         expectedModel.updateTransactionList(CARL.getTransactions());
+        // find transactions in expectedModel
         expectedModel.updateTransactionListPredicate(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(CARL.getTransactions(), model.getFilteredTransactionList());
@@ -89,9 +98,9 @@ public class FindTransactionCommandTest {
     @Test
     public void execute_transactionListView_throwsCommandException() {
         TransactionContainsKeywordsPredicate predicate = preparePredicate(" ");
-        FindTransactionCommand command = new FindTransactionCommand(Index.fromOneBased(3), predicate);
-        model.setIsViewTransactions(true);
-        String expectedMessage = String.format(Messages.MESSAGE_MUST_BE_PERSON_LIST, "findt");
+        FindTransactionCommand command = new FindTransactionCommand(predicate);
+        model.setIsViewTransactions(false);
+        String expectedMessage = String.format(Messages.MESSAGE_MUST_BE_TRANSACTION_LIST, "findt");
         assertCommandFailure(command, model, expectedMessage);
     }
 
@@ -99,8 +108,7 @@ public class FindTransactionCommandTest {
     public void toStringMethod() {
         TransactionContainsKeywordsPredicate predicate =
                 new TransactionContainsKeywordsPredicate(Arrays.asList("keyword"));
-        FindTransactionCommand findTransactionCommand =
-                new FindTransactionCommand(Index.fromOneBased(1), predicate);
+        FindTransactionCommand findTransactionCommand = new FindTransactionCommand(predicate);
         String expected = FindTransactionCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
         assertEquals(expected, findTransactionCommand.toString());
     }

--- a/src/test/java/seedu/address/logic/commands/FindTransactionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindTransactionCommandTest.java
@@ -96,7 +96,7 @@ public class FindTransactionCommandTest {
     }
 
     @Test
-    public void execute_transactionListView_throwsCommandException() {
+    public void execute_personListView_throwsCommandException() {
         TransactionContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindTransactionCommand command = new FindTransactionCommand(predicate);
         model.setIsViewTransactions(false);

--- a/src/test/java/seedu/address/logic/parser/FindTransactionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindTransactionCommandParserTest.java
@@ -8,7 +8,6 @@ import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.FindTransactionCommand;
 import seedu.address.model.person.TransactionContainsKeywordsPredicate;
 
@@ -22,26 +21,14 @@ public class FindTransactionCommandParserTest {
     }
 
     @Test
-    public void parse_missingParts_throwsParseException() {
-        //no index specified
-        String userInputWithNoIndex = "keyword1 keyword2";
-        assertParseFailure(parser, userInputWithNoIndex,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindTransactionCommand.MESSAGE_USAGE));
-        //no description specified
-        String userInputWithNoDescription = "1";
-        assertParseFailure(parser, userInputWithNoDescription,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindTransactionCommand.MESSAGE_USAGE));
-    }
-    @Test
     public void parse_validArgs_returnsFindTransactionCommand() {
         // no leading and trailing whitespaces
-        FindTransactionCommand expectedFindTransactionCommand =
-                new FindTransactionCommand(Index.fromOneBased(1),
-                        new TransactionContainsKeywordsPredicate(Arrays.asList("invest", "materials")));
-        assertParseSuccess(parser, "1 invest materials", expectedFindTransactionCommand);
+        FindTransactionCommand expectedFindTransactionCommand = new FindTransactionCommand(
+                new TransactionContainsKeywordsPredicate(Arrays.asList("invest", "materials")));
+        assertParseSuccess(parser, "invest materials", expectedFindTransactionCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " 1\n invest \n \t materials  \t", expectedFindTransactionCommand);
+        assertParseSuccess(parser, " \n invest \n \t materials  \t", expectedFindTransactionCommand);
     }
 
 }


### PR DESCRIPTION
Fixes #129

Command usage example:
1. `listt 1`
2. `findt materials`
result:
![image](https://github.com/user-attachments/assets/dbf5fe1e-80cc-4b0b-88f8-c36bb202a6a7)
