### PR TITLE
Change `summary` implementation to use `Predicate`

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SummaryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SummaryCommand.java
@@ -1,19 +1,14 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.DateTimeUtil.DEFAULT_DATE_FORMATTER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_END_MONTH;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START_MONTH;
-
-import java.time.LocalDate;
-import java.time.YearMonth;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Transaction;
+import seedu.address.model.person.TransactionDatePredicate;
 
 /**
  * Summarizes the transactions whose dates range between the first day of start month and the last day of end month.
@@ -31,18 +26,15 @@ public class SummaryCommand extends Command {
             + "Example: " + COMMAND_WORD + " " + PREFIX_START_MONTH + "2024-09 " + PREFIX_END_MONTH + "2024-12";
 
     public static final String MESSAGE_SUCCESS = "The total amount of transactions from %s to %s is: $%.2f";
-    private final YearMonth startMonth;
-    private final YearMonth endMonth;
+    private final TransactionDatePredicate predicate;
 
     /**
      * Creates a SummaryCommand to summarize the transactions in the range between start month and end month inclusive.
      *
-     * @param start the start month.
-     * @param end the end month.
+     * @param predicate the predicate containing the start and end month.
      */
-    public SummaryCommand(YearMonth start, YearMonth end) {
-        this.startMonth = start;
-        this.endMonth = end;
+    public SummaryCommand(TransactionDatePredicate predicate) {
+        this.predicate = predicate;
     }
     @Override
     public CommandResult execute(Model model) throws CommandException {
@@ -51,19 +43,10 @@ public class SummaryCommand extends Command {
         if (!model.getIsViewTransactions()) {
             throw new CommandException(String.format(Messages.MESSAGE_MUST_BE_TRANSACTION_LIST, COMMAND_WORD));
         }
-
-        LocalDate startDate = startMonth.atDay(1);
-        LocalDate endDate = endMonth.atEndOfMonth();
-
-        List<Transaction> transactionsInRange = model.getFilteredTransactionList().stream()
-                .filter(transaction -> (
-                        transaction.getDate().isEqual(startDate) || transaction.getDate().isAfter(startDate))
-                        && (transaction.getDate().isEqual(endDate) || transaction.getDate().isBefore(endDate)))
-                .collect(Collectors.toList());
-        model.updateTransactionList(transactionsInRange);
-        double summary = transactionsInRange.stream().mapToDouble(Transaction::getAmount).sum();
-        return new CommandResult(String.format(MESSAGE_SUCCESS, startDate.format(DEFAULT_DATE_FORMATTER),
-                endDate.format(DEFAULT_DATE_FORMATTER), summary));
+        model.updateTransactionListPredicate(predicate);
+        double summary = model.getFilteredTransactionList().stream().mapToDouble(Transaction::getAmount).sum();
+        return new CommandResult(String.format(MESSAGE_SUCCESS, predicate.getFormattedStartDate(),
+                predicate.getFormattedEndDate(), summary));
     }
 
     @Override
@@ -75,6 +58,6 @@ public class SummaryCommand extends Command {
             return false;
         }
         SummaryCommand otherCommand = (SummaryCommand) other;
-        return this.startMonth.equals(otherCommand.startMonth) && this.endMonth.equals(otherCommand.endMonth);
+        return this.predicate.equals(otherCommand.predicate);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/SummaryCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SummaryCommandParser.java
@@ -9,6 +9,7 @@ import java.time.YearMonth;
 
 import seedu.address.logic.commands.SummaryCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.TransactionDatePredicate;
 
 /**
  * Parses input arguments and creates a new SummaryCommand object.
@@ -30,6 +31,6 @@ public class SummaryCommandParser implements Parser<SummaryCommand> {
         if (start.isAfter(end)) {
             throw new ParseException(MESSAGE_INVALID_DATE_RANGE);
         }
-        return new SummaryCommand(start, end);
+        return new SummaryCommand(new TransactionDatePredicate(start, end));
     }
 }

--- a/src/main/java/seedu/address/model/person/TransactionDatePredicate.java
+++ b/src/main/java/seedu/address/model/person/TransactionDatePredicate.java
@@ -1,0 +1,56 @@
+package seedu.address.model.person;
+
+import static seedu.address.commons.util.DateTimeUtil.DEFAULT_DATE_FORMATTER;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Transaction}'s {@code date} is within the range between start and end month.
+ */
+public class TransactionDatePredicate implements Predicate<Transaction> {
+    private final LocalDate startDate;
+    private final LocalDate endDate;
+
+    /**
+     * Creates a TransactionDatePredicate.
+     *
+     * @param start the start month.
+     * @param end the end month.
+     */
+    public TransactionDatePredicate(YearMonth start, YearMonth end) {
+        this.startDate = start.atDay(1);
+        this.endDate = end.atEndOfMonth();
+    }
+    @Override
+    public boolean test(Transaction transaction) {
+        return transaction.getDate().isEqual(startDate)
+                || transaction.getDate().isEqual(endDate)
+                || (transaction.getDate().isAfter(startDate) && transaction.getDate().isBefore(endDate));
+    }
+
+    public String getFormattedStartDate() {
+        return startDate.format(DEFAULT_DATE_FORMATTER);
+    }
+
+    public String getFormattedEndDate() {
+        return endDate.format(DEFAULT_DATE_FORMATTER);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof TransactionDatePredicate)) {
+            return false;
+        }
+
+        TransactionDatePredicate otherTransactionDatePredicate = (TransactionDatePredicate) other;
+        return startDate.equals(otherTransactionDatePredicate.startDate)
+                && endDate.equals(otherTransactionDatePredicate.endDate);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/SummaryCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SummaryCommandTest.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.commons.util.DateTimeUtil.DEFAULT_DATE_FORMATTER;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
@@ -18,6 +17,7 @@ import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.TransactionDatePredicate;
 
 public class SummaryCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
@@ -26,13 +26,13 @@ public class SummaryCommandTest {
     @Test
     public void equals() {
         // same object -> returns true
-        SummaryCommand summaryCommand = new SummaryCommand(YearMonth.parse("2020-11"),
-                YearMonth.parse("2022-01"));
+        SummaryCommand summaryCommand = new SummaryCommand(
+                new TransactionDatePredicate(YearMonth.parse("2020-11"), YearMonth.parse("2022-01")));
         assertTrue(summaryCommand.equals(summaryCommand));
 
         // same values -> returns true
-        SummaryCommand summaryCommandCopy = new SummaryCommand(YearMonth.parse("2020-11"),
-                YearMonth.parse("2022-01"));
+        SummaryCommand summaryCommandCopy = new SummaryCommand(
+                new TransactionDatePredicate(YearMonth.parse("2020-11"), YearMonth.parse("2022-01")));
         assertTrue(summaryCommand.equals(summaryCommandCopy));
 
         // different types -> returns false
@@ -41,57 +41,49 @@ public class SummaryCommandTest {
         // null -> returns false
         assertFalse(summaryCommand.equals(null));
         // different start month -> returns false
-        SummaryCommand summaryCommandDifferentStartMonth = new SummaryCommand(YearMonth.parse("2020-12"),
-                YearMonth.parse("2022-01"));
+        SummaryCommand summaryCommandDifferentStartMonth = new SummaryCommand(
+                new TransactionDatePredicate(YearMonth.parse("2020-12"), YearMonth.parse("2022-01")));
         assertFalse(summaryCommand.equals(summaryCommandDifferentStartMonth));
         // different end month -> returns false
-        SummaryCommand summaryCommandDifferentEndMonth = new SummaryCommand(YearMonth.parse("2020-11"),
-                YearMonth.parse("2022-02"));
+        SummaryCommand summaryCommandDifferentEndMonth = new SummaryCommand(
+                new TransactionDatePredicate(YearMonth.parse("2020-11"), YearMonth.parse("2022-02")));
         assertFalse(summaryCommand.equals(summaryCommandDifferentEndMonth));
         // different start and end month -> returns false
-        SummaryCommand summaryCommandDifferentStartAndEndMonth = new SummaryCommand(YearMonth.parse("2020-12"),
-                YearMonth.parse("2022-02"));
+        SummaryCommand summaryCommandDifferentStartAndEndMonth = new SummaryCommand(
+                new TransactionDatePredicate(YearMonth.parse("2020-12"), YearMonth.parse("2022-02")));
         assertFalse(summaryCommand.equals(summaryCommandDifferentStartAndEndMonth));
     }
     @Test
     public void execute_validMonthRange_success() {
         // one month
-        SummaryCommand summaryCommand = new SummaryCommand(YearMonth.parse("2024-08"),
-                YearMonth.parse("2024-08"));
+        TransactionDatePredicate predicate = new TransactionDatePredicate(
+                YearMonth.parse("2024-08"), YearMonth.parse("2024-08"));
+        SummaryCommand summaryCommand = new SummaryCommand(predicate);
         showPersonAtIndex(expectedModel, Index.fromOneBased(3));
         expectedModel.updateTransactionList(CARL.getTransactions());
-        expectedModel.updateTransactionList(CARL.getTransactions().stream().filter(transaction ->
-                transaction.getDate().getYear() == 2024 && transaction.getDate().getMonthValue() == 8)
-                .collect(java.util.stream.Collectors.toList()));
+        expectedModel.updateTransactionListPredicate(predicate);
         showPersonAtIndex(model, Index.fromOneBased(3));
         model.updateTransactionList(CARL.getTransactions());
         assertCommandSuccess(summaryCommand, model, String.format(SummaryCommand.MESSAGE_SUCCESS,
-                        YearMonth.parse("2024-08").atDay(1).format(DEFAULT_DATE_FORMATTER),
-                        YearMonth.parse("2024-08").atEndOfMonth().format(DEFAULT_DATE_FORMATTER), -1000.0),
-                expectedModel);
+                        predicate.getFormattedStartDate(), predicate.getFormattedEndDate(), -1000.0), expectedModel);
         // multiple months
         model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-        SummaryCommand summaryCommandMultipleMonths = new SummaryCommand(YearMonth.parse("2024-08"),
-                YearMonth.parse("2024-11"));
+        predicate = new TransactionDatePredicate(YearMonth.parse("2024-08"), YearMonth.parse("2024-11"));
+        SummaryCommand summaryCommandMultipleMonths = new SummaryCommand(predicate);
         showPersonAtIndex(expectedModel, Index.fromOneBased(3));
         expectedModel.updateTransactionList(CARL.getTransactions());
-        expectedModel.updateTransactionList(CARL.getTransactions().stream().filter(transaction -> (
-                transaction.getDate().getYear() == 2024 && transaction.getDate().getMonthValue() >= 8
-                        && transaction.getDate().getMonthValue() <= 11))
-                .collect(java.util.stream.Collectors.toList()));
+        expectedModel.updateTransactionListPredicate(predicate);
         showPersonAtIndex(model, Index.fromOneBased(3));
         model.updateTransactionList(CARL.getTransactions());
         assertCommandSuccess(summaryCommandMultipleMonths, model, String.format(SummaryCommand.MESSAGE_SUCCESS,
-                        YearMonth.parse("2024-08").atDay(1).format(DEFAULT_DATE_FORMATTER),
-                        YearMonth.parse("2024-11").atEndOfMonth().format(DEFAULT_DATE_FORMATTER), -1100.0),
-                expectedModel);
+                        predicate.getFormattedStartDate(), predicate.getFormattedEndDate(), -1100.0), expectedModel);
     }
 
     @Test
     public void execute_personListView_throwsCommandException() {
-        SummaryCommand summaryCommand = new SummaryCommand(YearMonth.parse("2024-08"),
-                YearMonth.parse("2024-08"));
+        SummaryCommand summaryCommand = new SummaryCommand(
+                new TransactionDatePredicate(YearMonth.parse("2024-08"), YearMonth.parse("2024-08")));
         String expectedMessage = String.format(Messages.MESSAGE_MUST_BE_TRANSACTION_LIST, "summary");
         assertCommandFailure(summaryCommand, model, expectedMessage);
     }

--- a/src/test/java/seedu/address/logic/parser/SummaryCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SummaryCommandParserTest.java
@@ -11,6 +11,7 @@ import java.time.YearMonth;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.SummaryCommand;
+import seedu.address.model.person.TransactionDatePredicate;
 
 public class SummaryCommandParserTest {
     private SummaryCommandParser parser = new SummaryCommandParser();
@@ -48,8 +49,8 @@ public class SummaryCommandParserTest {
     @Test
     public void parse_validArgs_returnsSummaryCommand() {
         String validArgs = "        s/2022-05       e/2022-06       ";
-        SummaryCommand expectedSummaryCommand =
-                new SummaryCommand(YearMonth.parse("2022-05"), YearMonth.parse("2022-06"));
+        SummaryCommand expectedSummaryCommand = new SummaryCommand(
+                new TransactionDatePredicate(YearMonth.parse("2022-05"), YearMonth.parse("2022-06")));
         assertParseSuccess(parser, validArgs, expectedSummaryCommand);
     }
 }

--- a/src/test/java/seedu/address/model/person/TransactionDatePredicateTest.java
+++ b/src/test/java/seedu/address/model/person/TransactionDatePredicateTest.java
@@ -1,0 +1,82 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.util.DateTimeUtil;
+
+public class TransactionDatePredicateTest {
+    @Test
+    public void equals() {
+        YearMonth startMonth1 = YearMonth.parse("2020-11");
+        YearMonth endMonth1 = YearMonth.parse("2022-01");
+        YearMonth startMonth2 = YearMonth.parse("2020-12");
+        YearMonth endMonth2 = YearMonth.parse("2022-02");
+
+        TransactionDatePredicate firstPredicate =
+                new TransactionDatePredicate(startMonth1, endMonth1);
+        TransactionDatePredicate secondPredicate =
+                new TransactionDatePredicate(startMonth2, endMonth2);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        TransactionDatePredicate firstPredicateCopy =
+                new TransactionDatePredicate(startMonth1, endMonth1);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different dates -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_dateWithinRange_returnsTrue() {
+        // within range
+        TransactionDatePredicate predicate =
+                new TransactionDatePredicate(YearMonth.parse("2024-11"), YearMonth.parse("2024-12"));
+        assertTrue(predicate.test(new Transaction(
+                "invest", 1000, "ABC Company",
+                LocalDate.parse("2024-12-30", DateTimeUtil.DEFAULT_DATE_PARSER))));
+
+        // edge date
+        predicate = new TransactionDatePredicate(YearMonth.parse("2024-11"), YearMonth.parse("2024-12"));
+        assertTrue(predicate.test(new Transaction(
+                "raw materials", 1000, "ABC Company",
+                LocalDate.parse("2024-11-01", DateTimeUtil.DEFAULT_DATE_PARSER))));
+        assertTrue(predicate.test(new Transaction(
+                "raw materials", 1000, "ABC Company",
+                LocalDate.parse("2024-12-31", DateTimeUtil.DEFAULT_DATE_PARSER))));
+    }
+
+    @Test
+    public void test_dateNotWithinRange_returnsFalse() {
+        // not within range
+        TransactionDatePredicate predicate =
+                new TransactionDatePredicate(YearMonth.parse("2024-11"), YearMonth.parse("2024-12"));
+        assertFalse(predicate.test(new Transaction(
+                "invest", 1000, "ABC Company",
+                LocalDate.parse("2024-10-29", DateTimeUtil.DEFAULT_DATE_PARSER))));
+
+        // edge date
+        predicate = new TransactionDatePredicate(YearMonth.parse("2024-11"), YearMonth.parse("2024-12"));
+        assertFalse(predicate.test(new Transaction(
+                "raw materials", 1000, "ABC Company",
+                LocalDate.parse("2024-10-31", DateTimeUtil.DEFAULT_DATE_PARSER))));
+        assertFalse(predicate.test(new Transaction(
+                "raw materials", 1000, "ABC Company",
+                LocalDate.parse("2025-01-01", DateTimeUtil.DEFAULT_DATE_PARSER))));
+    }
+}
+


### PR DESCRIPTION
Fixes #174 

![image](https://github.com/user-attachments/assets/aad14801-6710-42fe-85da-4f6923f7ae1d)
Now can use `summary` consecutively
e.g. 
1. `summary s/2024-11 e/2024-12`
2. `summary s/2022-01 e/2024-06`

and the results will be based on the underlying list of all transactions of a person
by right should also be able to use consecutively with `findt` since they are both implemented using `Predicate`