### PR TITLE
Improve add command for more flexible parsing

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -115,18 +115,34 @@ Format: `add n/NAME c/COMPANY p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]…​`
 
 * A client can have any number of tags (including 0).<br>
 
-* Names are automatically formatted for you (i.e natural name casing, name ordinals, excess spacing).<br>
+* Names are automatically formatted for you (i.e natural name casing, name ordinals below 10, excess spacing).<br>
 
 * Phone numbers can also take in additional info (i.e `(+XXX)` in front for country codes, `[Note]` behind for any notes).<br>
 
 * Phone numbers also allow up to 1 space between numbers to cater to your formatting style (e.g `123 45 678` and `1234 5678` allowed and recorded verbatim).<br>
+
+* Phone numbers are also automatically formatted (i.e main number ignores non-numeric characters and excess spaces).<br>
 </box>
 
 Examples:
 * `add n/John Doe c/ABC Inc. p/98765432 e/johnd@example.com a/John street, block 123, #01-01`
 * `add n/Betsy Crowe t/friend e/betsycrowe@example.com a/Newgate Prison p/1234567 t/criminal c/XYZ Co.`
-* `add n/jOhN   dOE xvii c/ABC Inc. p/98765432 e/johnd@example.com a/John street, block 123, #01-01` (This name is recorded as `John Doe XVII`)
+* `add n/jOhN   dOE vii c/ABC Inc. p/98765432 e/johnd@example.com a/John street, block 123, #01-01` (This name is recorded as `John Doe VII`)
 * `add n/John Doe c/ABC Inc. p/(+65) 987 654 32 [HP] e/johnd@example.com a/John street, block 123, #01-01` (This phone number is recorded exactly as  `(+65) 987 654 32 [HP]`)
+
+<box type="info" seamless>
+
+**Notes on name and phone parsing:** <br>
+
+* Name casing and spacing typos are tedious, hence our autocorrection and duplicate handling.<br>
+
+* It should be impossible for you to meet 10 generations with the same name, hence our limit on the name ordinal.<br>
+
+* Country codes range from +1 to +999, and [Notes] should be for very brief add-on info about the number.<br>
+
+* Phone numbers are very generously autocorrected, but we can't correct the (+XXX) country code and [Notes].
+
+</box>
 
 #### Listing all clients : `list`
 

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -52,7 +52,7 @@ public class Name {
                 String word = words[i];
 
                 // Check if it's the last word and is a Roman numeral
-                if (i == words.length - 1 && isRomanNumeral(word)) {
+                if (i == words.length - 1 && isSimpleRomanNumeral(word)) {
                     formattedName.append(word.toUpperCase());
                 } else {
                     // Regular name word - capitalize first letter only
@@ -70,41 +70,22 @@ public class Name {
         return formattedName.toString();
     }
     /**
-     * Verifies whether a {@code String} is a Roman numeral.
+     * Verifies whether a {@code String} is a Roman numeral less than 10.
      *
      * @param word Any word.
      */
-    private static boolean isRomanNumeral(String word) {
+    private static boolean isSimpleRomanNumeral(String word) {
         // Convert to uppercase for checking
         word = word.toUpperCase();
 
-        // Check if the word only contains valid Roman numeral characters
-        if (!word.matches("^[IVXLCDM]+$")) {
+        // Only allow I and V
+        if (!word.matches("^[IV]+$")) {
             return false;
         }
 
-        // Additional validation rules for Roman numerals
-        // Check for valid patterns and combinations
-        if (word.matches(".*I{4,}.*")
-                || word.matches(".*V{2,}.*")
-                || word.matches(".*X{4,}.*")
-                || word.matches(".*L{2,}.*")
-                || word.matches(".*C{4,}.*")
-                || word.matches(".*D{2,}.*")
-                || word.matches(".*M{4,}.*")) {
-            return false;
-        }
-
-        // Check for invalid sequences
-        if (word.matches(".*I[LCDM].*")
-                || word.matches(".*V[XLCDM].*")
-                || word.matches(".*X[CDM].*")
-                || word.matches(".*L[CDM].*")
-                || word.matches(".*D[M].*")) {
-            return false;
-        }
-
-        return true;
+        // Valid patterns for numbers 1-9:
+        // I, II, III, IV, V, VI, VII, VIII, IX
+        return word.matches("^(I{1,3}|IV|V|VI{1,3}|IX)$");
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -13,17 +13,19 @@ public class Phone {
             "Phone numbers should be in the format: (+XXX) 123 456 789 [notes]\n"
                     + "where:\n"
                     + "- Country code (+XXX) is optional and X must be 1-3 digits\n"
-                    + "- Main phone number must contain only digits with optional single spaces between numbers\n"
-                    + "- [notes] is optional and must be maximum 10 characters";
+                    + "- Main phone number must contain digits with optional single spaces between numbers\n"
+                    + "- [notes] is optional and must be maximum 10 characters\n"
+                    + "Note: Special characters and letters in the phone number section will be automatically removed";
 
-    // Regex breakdown:
-    // ^                        - Start of string
-    // (?:\(\+\d{1,3}\)\s)?    - Optional country code in format (+X) to (+XXX)
-    // \d+(?:\s\d+)*           - Main phone number with optional single spaces between digits
-    // (?:\s\[.{1,10}\])?      - Optional notes in [] with max 10 chars
-    // $                        - End of string
-    public static final String VALIDATION_REGEX =
-            "^(?:\\(\\+\\d{1,3}\\)\\s)?\\d+(?:\\s\\d+)*(?:\\s\\[.{1,10}\\])?$";
+    // Regex specifically for validating country code format if present
+    private static final String COUNTRY_CODE_REGEX = "^\\(\\+\\d{1,3}\\).*$";
+
+    // Regex specifically for validating notes format if present
+    private static final String NOTES_REGEX = ".*\\[.{1,10}\\]$";
+
+    // Regex for validating the overall structure without notes validation
+    private static final String MAIN_STRUCTURE_REGEX =
+            "^(?:\\(\\+\\d{1,3}\\)\\s)?[\\d\\s\\W\\w]+$";
 
     public final String value;
 
@@ -35,14 +37,116 @@ public class Phone {
     public Phone(String phone) {
         requireNonNull(phone);
         checkArgument(isValidPhone(phone), MESSAGE_CONSTRAINTS);
-        value = phone;
+        value = normalizePhoneNumber(phone);
+    }
+
+    /**
+     * Normalizes the phone number by:
+     * 1. Preserving valid country code if present
+     * 2. Removing all non-numeric characters from the main phone number section
+     * 3. Normalizing spaces between digits (multiple spaces become single space)
+     * 4. Preserving the notes section if present
+     */
+    private String normalizePhoneNumber(String phone) {
+        // Split the input into its components
+        String countryCode = "";
+        String notes = "";
+        String mainNumber = phone;
+
+        // Extract country code if present
+        if (phone.startsWith("(+")) {
+            int closeParen = phone.indexOf(")");
+            countryCode = phone.substring(0, closeParen + 1);
+            mainNumber = phone.substring(closeParen + 1).trim();
+        }
+
+        // Extract notes if present
+        if (mainNumber.contains("[")) {
+            int openBracket = mainNumber.lastIndexOf("[");
+            notes = mainNumber.substring(openBracket);
+            mainNumber = mainNumber.substring(0, openBracket).trim();
+        }
+
+        // Process main number:
+        // 1. Remove all non-numeric characters
+        // 2. Split by digits to preserve spacing
+        StringBuilder normalizedNumber = new StringBuilder();
+        String[] numberGroups = mainNumber.split("\\s+");
+
+        for (int i = 0; i < numberGroups.length; i++) {
+            // Remove all non-numeric characters from each group
+            String digits = numberGroups[i].replaceAll("[^0-9]", "");
+            if (!digits.isEmpty()) {
+                if (i > 0 && !normalizedNumber.isEmpty()) {
+                    normalizedNumber.append(" ");
+                }
+                normalizedNumber.append(digits);
+            }
+        }
+
+        // Combine all parts
+        StringBuilder result = new StringBuilder();
+        if (!countryCode.isEmpty()) {
+            result.append(countryCode).append(" ");
+        }
+        result.append(normalizedNumber);
+        if (!notes.isEmpty()) {
+            result.append(" ").append(notes);
+        }
+
+        return result.toString();
     }
 
     /**
      * Returns true if a given string is a valid phone number.
+     * Validates both the format and content after normalization.
      */
     public static boolean isValidPhone(String test) {
-        return test.matches(VALIDATION_REGEX);
+        // First check if there's a country code and if it's valid
+        if (test.startsWith("(+") && !test.matches(COUNTRY_CODE_REGEX)) {
+            return false;
+        }
+
+        // Check if there are notes and if they're valid
+        if (test.contains("[")) {
+            if (!test.matches(NOTES_REGEX)) {
+                return false;
+            }
+            // Remove notes for main structure validation
+            test = test.substring(0, test.lastIndexOf("[")).trim();
+        }
+
+        // Check main structure (without notes)
+        if (!test.matches(MAIN_STRUCTURE_REGEX)) {
+            return false;
+        }
+
+        // Validate the normalized form to ensure we have digits after stripping
+        String normalized = normalizeForValidation(test);
+        return !normalized.isEmpty();
+    }
+
+    /**
+     * Helper method to normalize a phone number for validation purposes.
+     * Similar to normalizePhoneNumber but only returns the numeric part for validation.
+     */
+    private static String normalizeForValidation(String phone) {
+        String mainNumber = phone;
+
+        // Remove country code if present
+        if (phone.startsWith("(+")) {
+            int closeParen = phone.indexOf(")");
+            mainNumber = phone.substring(closeParen + 1).trim();
+        }
+
+        // Remove notes if present
+        if (mainNumber.contains("[")) {
+            int openBracket = mainNumber.lastIndexOf("[");
+            mainNumber = mainNumber.substring(0, openBracket).trim();
+        }
+
+        // Return only the digits
+        return mainNumber.replaceAll("[^0-9]", "");
     }
 
     @Override

--- a/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
@@ -8,7 +8,7 @@
   }, {
     "name": "Person With Invalid Phone Field",
     "company": "Apple Co.",
-    "phone": "948asdf2424",
+    "phone": "(+1234) 948asdf2424",
     "email": "hans@example.com",
     "address": "4th street"
   } ]

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -63,7 +63,7 @@ public class CommandTestUtil {
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_COMPANY_DESC = " " + PREFIX_COMPANY + " "; // empty string not allowed
-    public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
+    public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "(+a) 123"; // 'a' not allowed in country code
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -25,7 +25,7 @@ import seedu.address.model.tag.Tag;
 
 public class ParserUtilTest {
     private static final String INVALID_NAME = "R@chel";
-    private static final String INVALID_PHONE = "+651234";
+    private static final String INVALID_PHONE = "(+6512) 34";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -27,22 +27,20 @@ public class PhoneTest {
         // invalid phone numbers
         assertFalse(Phone.isValidPhone("")); // empty string
         assertFalse(Phone.isValidPhone(" ")); // spaces only
-        assertFalse(Phone.isValidPhone("phone")); // non-numeric
-        assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
         assertFalse(Phone.isValidPhone("(+9999) 93121534")); // with country code too long
         assertFalse(Phone.isValidPhone("(+) 93121534")); // with blank country code
-        assertFalse(Phone.isValidPhone("93  121534")); // with more than 1 space
         assertFalse(Phone.isValidPhone("93121534 [Office And Others]")); // with note > 10 chars
 
         // valid phone numbers
         assertTrue(Phone.isValidPhone("91")); // short phone number
         assertTrue(Phone.isValidPhone("9312 1534")); // spaces allowed
+        assertTrue(Phone.isValidPhone("93  121534")); // with more than 1 space
         assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers
         assertTrue(Phone.isValidPhone("(+999) 93121534")); // with country code length 3
         assertTrue(Phone.isValidPhone("93121534 [Office]")); // with note
         assertTrue(Phone.isValidPhone("(+999) 93121534 [Office]")); // with both country code and note
         assertTrue(Phone.isValidPhone("93121534 [Not Office]")); // with note = 10 chars
-        assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers
+        assertTrue(Phone.isValidPhone("124!@#$%^&*()_+{}ASDFGHJKasdfg033123")); // with characters
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -21,7 +21,7 @@ import seedu.address.model.person.Phone;
 public class JsonAdaptedPersonTest {
     private static final String INVALID_NAME = "R@chel";
     private static final String INVALID_COMPANY = " ";
-    private static final String INVALID_PHONE = "+651234";
+    private static final String INVALID_PHONE = "(+1234) 1234";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";


### PR DESCRIPTION
Restrict name parsing to ordinals <10 and fix mistakes where non-numerals like XIVI were parsed as numerals

Phone parsing is now extremely flexible (main phone number strips all non-numeric characters and excess (>1) spacing. Single spacing is still available for styling customisation)