### PR TITLE
Update parser to handle invalid dates 

### DIFF
--- a/src/main/java/seedu/address/commons/util/DateTimeUtil.java
+++ b/src/main/java/seedu/address/commons/util/DateTimeUtil.java
@@ -1,11 +1,14 @@
 package seedu.address.commons.util;
 
 import java.time.format.DateTimeFormatter;
+import java.time.format.ResolverStyle;
 
 /**
  * A class for formatting and parsing LocalDate objects
  */
 public class DateTimeUtil {
-    public static final DateTimeFormatter DEFAULT_DATE_PARSER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-    public static final DateTimeFormatter DEFAULT_DATE_FORMATTER = DateTimeFormatter.ofPattern("dd-MMM-yyyy");
+    public static final DateTimeFormatter DEFAULT_DATE_PARSER = DateTimeFormatter.ofPattern("uuuu-MM-dd")
+            .withResolverStyle(ResolverStyle.STRICT);
+    public static final DateTimeFormatter DEFAULT_DATE_FORMATTER = DateTimeFormatter.ofPattern("dd-MMM-uuuu")
+            .withResolverStyle(ResolverStyle.STRICT);
 }

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -48,7 +48,7 @@ public class Messages {
     public static final String MESSAGE_EMPTY_DATE = "Date should not be blank!";
 
     public static final String MESSAGE_EMPTY_PERSON_LIST =
-            "Current person list is empty!\n" + "%1$s command must only be used on non-empty person list.";
+            "Current client list is empty!\n" + "%1$s command must only be used on non-empty client list.";
 
     public static final String MESSAGE_EMPTY_TRANSACTION_LIST =
             "Invalid command: The current transaction list is empty.";

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -93,7 +93,10 @@ public class CommandTestUtil {
     public static final String VALID_AMOUNT_INPUT = " " + PREFIX_AMOUNT + VALID_AMOUNT;
     public static final String VALID_OTHER_PARTY_INPUT = " " + PREFIX_OTHER_PARTY + VALID_OTHER_PARTY;
     public static final String VALID_DATE_INPUT = " " + PREFIX_DATE + VALID_DATE;
-    public static final String INVALID_DATE_INPUT = " " + PREFIX_DATE + "22-10-2024"; // incorrect date format
+    public static final String INCORRECT_DATE_FORMAT_INPUT = " " + PREFIX_DATE + "22-9-2024";
+    public static final String INVALID_DATE_INPUT = " " + PREFIX_DATE + "2023-02-29";
+    public static final String WHITE_SPACE = " ";
+
 
 
     /**

--- a/src/test/java/seedu/address/logic/parser/AddTransactionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddTransactionCommandParserTest.java
@@ -1,8 +1,13 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_EMPTY_AMOUNT;
+import static seedu.address.logic.Messages.MESSAGE_EMPTY_DATE;
+import static seedu.address.logic.Messages.MESSAGE_EMPTY_DESCRIPTION;
+import static seedu.address.logic.Messages.MESSAGE_EMPTY_OTHER_PARTY;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_DATE_FORMAT;
 //import static seedu.address.logic.commands.CommandTestUtil.INVALID_AMOUNT_INPUT;
+import static seedu.address.logic.commands.CommandTestUtil.INCORRECT_DATE_FORMAT_INPUT;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_AMOUNT_INPUT;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DATE_INPUT;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_AMOUNT;
@@ -13,6 +18,11 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_DESCRIPTION;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DESCRIPTION_INPUT;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_OTHER_PARTY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_OTHER_PARTY_INPUT;
+import static seedu.address.logic.commands.CommandTestUtil.WHITE_SPACE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_AMOUNT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_OTHER_PARTY;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
@@ -31,6 +41,7 @@ public class AddTransactionCommandParserTest {
 
     @Test
     public void parse_missingParts_failure() {
+
         //no index specified
         String userInputWithNoIndex = VALID_DESCRIPTION_INPUT + VALID_AMOUNT_INPUT + VALID_OTHER_PARTY_INPUT
                 + VALID_DATE_INPUT;
@@ -61,6 +72,31 @@ public class AddTransactionCommandParserTest {
     }
 
     @Test
+    public void parse_blankParts_failure() {
+
+        //blank description
+        String userInputWithBlankDescription = "1" + PREFIX_DESCRIPTION + WHITE_SPACE + VALID_AMOUNT_INPUT
+                + VALID_OTHER_PARTY_INPUT + VALID_DATE_INPUT;
+        assertParseFailure(parser, userInputWithBlankDescription, MESSAGE_EMPTY_DESCRIPTION);
+
+        //blank amount
+        String userInputWithBlankAmount = "1" + VALID_DESCRIPTION_INPUT + WHITE_SPACE + PREFIX_AMOUNT + WHITE_SPACE
+                + VALID_OTHER_PARTY_INPUT + VALID_DATE_INPUT;
+        assertParseFailure(parser, userInputWithBlankAmount, MESSAGE_EMPTY_AMOUNT);
+
+        //blank other party
+        String userInputWithBlankOtherParty = "1" + VALID_DESCRIPTION_INPUT + VALID_AMOUNT_INPUT
+                + WHITE_SPACE + PREFIX_OTHER_PARTY + WHITE_SPACE + VALID_DATE_INPUT;
+        assertParseFailure(parser, userInputWithBlankOtherParty, MESSAGE_EMPTY_OTHER_PARTY);
+
+        //blank date
+        String userInputWithBlankDate = "1" + VALID_DESCRIPTION_INPUT + VALID_AMOUNT_INPUT
+                + VALID_OTHER_PARTY_INPUT + WHITE_SPACE + PREFIX_DATE + WHITE_SPACE;
+        assertParseFailure(parser, userInputWithBlankDate, MESSAGE_EMPTY_DATE);
+    }
+
+
+    @Test
     public void parse_invalidPreamble_failure() {
 
         String userInputWithNoIndex = " " + VALID_DESCRIPTION_INPUT + VALID_AMOUNT_INPUT + VALID_OTHER_PARTY_INPUT
@@ -85,6 +121,15 @@ public class AddTransactionCommandParserTest {
         String userInputWithInvalidAmount = targetIndex.getOneBased() + VALID_DESCRIPTION_INPUT + INVALID_AMOUNT_INPUT
                 + VALID_OTHER_PARTY_INPUT + VALID_DATE_INPUT;
         assertParseFailure(parser, userInputWithInvalidAmount, Transaction.MESSAGE_CONSTRAINTS);
+    }
+
+
+    @Test
+    public void parse_incorrectDateFormat_failure() {
+        Index targetIndex = INDEX_SECOND_PERSON;
+        String userInputWithInvalidDate = targetIndex.getOneBased() + VALID_DESCRIPTION_INPUT + VALID_AMOUNT_INPUT
+                + VALID_OTHER_PARTY_INPUT + INCORRECT_DATE_FORMAT_INPUT;
+        assertParseFailure(parser, userInputWithInvalidDate, MESSAGE_INVALID_DATE_FORMAT);
     }
 
 

--- a/src/test/java/seedu/address/logic/parser/AddTransactionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddTransactionCommandParserTest.java
@@ -75,7 +75,7 @@ public class AddTransactionCommandParserTest {
     public void parse_blankParts_failure() {
 
         //blank description
-        String userInputWithBlankDescription = "1" + PREFIX_DESCRIPTION + WHITE_SPACE + VALID_AMOUNT_INPUT
+        String userInputWithBlankDescription = "1" + WHITE_SPACE + PREFIX_DESCRIPTION + WHITE_SPACE + VALID_AMOUNT_INPUT
                 + VALID_OTHER_PARTY_INPUT + VALID_DATE_INPUT;
         assertParseFailure(parser, userInputWithBlankDescription, MESSAGE_EMPTY_DESCRIPTION);
 

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -8,6 +8,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.time.format.ResolverStyle;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -34,6 +35,8 @@ public class ParserUtilTest {
     private static final String INVALID_DATE_1 = "2024-10-32";
     private static final String INVALID_DATE_2 = "2024-13-12";
     private static final String INVALID_DATE_3 = "2024-1-12";
+    private static final String INVALID_DATE_4 = "2024-09-31";
+    private static final String INVALID_DATE_5 = "2023-02-29";
     private static final String INVALID_YEAR_MONTH = "2020-13";
     private static final String INVALID_YEAR_MONTH_2 = "11-2020";
 
@@ -46,7 +49,9 @@ public class ParserUtilTest {
     private static final String VALID_AMOUNT_1 = "100";
     private static final String VALID_AMOUNT_2 = "100.5";
     private static final String VALID_AMOUNT_3 = "100.55";
-    private static final String VALID_DATE = "2024-10-30";
+    private static final String VALID_DATE_1 = "2024-10-30";
+    private static final String VALID_DATE_2 = "0000-10-30";
+    private static final String VALID_DATE_3 = "-0001-10-30";
     private static final String VALID_YEAR_MONTH = "2020-12";
 
     private static final String WHITESPACE = " \t\r\n";
@@ -241,16 +246,24 @@ public class ParserUtilTest {
         assertThrows(ParseException.class, () -> ParserUtil.parseAmount(INVALID_DATE_1));
         assertThrows(ParseException.class, () -> ParserUtil.parseAmount(INVALID_DATE_2));
         assertThrows(ParseException.class, () -> ParserUtil.parseAmount(INVALID_DATE_3));
+        assertThrows(ParseException.class, () -> ParserUtil.parseAmount(INVALID_DATE_4));
+        assertThrows(ParseException.class, () -> ParserUtil.parseAmount(INVALID_DATE_5));
+
     }
     @Test
     public void parseDate_validValueWithoutWhitespace_returnsLocalDate() throws ParseException {
-        assertEquals(LocalDate.parse(VALID_DATE, DateTimeUtil.DEFAULT_DATE_PARSER),
-                ParserUtil.parseDate(VALID_DATE));
+        assertEquals(LocalDate.parse(VALID_DATE_1, DateTimeUtil.DEFAULT_DATE_PARSER),
+                ParserUtil.parseDate(VALID_DATE_1));
+        assertEquals(LocalDate.parse(VALID_DATE_2, DateTimeUtil.DEFAULT_DATE_PARSER),
+                ParserUtil.parseDate(VALID_DATE_2));
+        assertEquals(LocalDate.parse(VALID_DATE_3, DateTimeUtil.DEFAULT_DATE_PARSER),
+                ParserUtil.parseDate(VALID_DATE_3));
     }
     @Test
     public void parseDate_validValueWithWhitespace_returnsLocalDate() throws Exception {
-        String dateWithWhitespace = WHITESPACE + VALID_DATE + WHITESPACE;
-        assertEquals(LocalDate.parse(VALID_DATE, DateTimeUtil.DEFAULT_DATE_PARSER),
+        String dateWithWhitespace = WHITESPACE + VALID_DATE_1 + WHITESPACE;
+        assertEquals(LocalDate.parse(VALID_DATE_1, DateTimeUtil.DEFAULT_DATE_PARSER
+                        .withResolverStyle(ResolverStyle.STRICT)),
                 ParserUtil.parseDate(dateWithWhitespace));
     }
 


### PR DESCRIPTION
Fixes #245

![image](https://github.com/user-attachments/assets/f401ce04-db73-4730-a6ea-60cd5f3cc092)
 Invalid dates no longer rounded off, error message is shown. 